### PR TITLE
Fix undefined behavior from sequence point rule violations.

### DIFF
--- a/shared/DSPFilters/include/DspFilters/Biquad.h
+++ b/shared/DSPFilters/include/DspFilters/Biquad.h
@@ -81,8 +81,10 @@ public:
   template <class StateType, typename Sample>
   void process (int numSamples, Sample* dest, StateType& state) const
   {
-    while (--numSamples >= 0)
-      *dest++ = state.process (*dest, *this);
+    while (--numSamples >= 0) {
+      *dest = state.process (*dest, *this);
+      dest++;
+    }
   }
 
 protected:
@@ -169,7 +171,8 @@ public:
       sectionPrev.m_b1 += db1;
       sectionPrev.m_b2 += db2;
 
-      *dest++ = state.process (*dest, sectionPrev);
+      *dest = state.process (*dest, sectionPrev);
+      dest++;
     }
   }
 
@@ -198,7 +201,8 @@ public:
       zPrev.zeros.second += dz1;
       zPrev.gain += dg;
 
-      *dest++ = state.process (*dest, Biquad (zPrev));
+      *dest = state.process (*dest, Biquad (zPrev));
+      dest++;
     }
   }
 

--- a/shared/DSPFilters/include/DspFilters/Cascade.h
+++ b/shared/DSPFilters/include/DspFilters/Cascade.h
@@ -120,8 +120,10 @@ public:
   template <class StateType, typename Sample>
   void process (int numSamples, Sample* dest, StateType& state) const
   {
-    while (--numSamples >= 0)
-      *dest++ = state.process (*dest, *this);
+    while (--numSamples >= 0) {
+      *dest = state.process (*dest, *this);
+      dest++;
+    }
   }
 
 protected:

--- a/shared/DSPFilters/include/DspFilters/Utilities.h
+++ b/shared/DSPFilters/include/DspFilters/Utilities.h
@@ -274,7 +274,8 @@ void fade (int samples,
 
   while (--samples >= 0)
   {
-    *dest++ = static_cast<Td>(*dest + t * (*src++ - *dest));
+    *dest = static_cast<Td>(*dest + t * (*src++ - *dest));
+    dest++;
     t += dt;
   }
 }
@@ -384,8 +385,10 @@ void multiply (int samples,
   }
   else
   {
-    while (--samples >= 0)
-      *dest++ = static_cast<Td>(*dest * factor);
+    while (--samples >= 0) {
+      *dest = static_cast<Td>(*dest * factor);
+      dest++;
+    }
   }
 }
 


### PR DESCRIPTION
Hi,

Here are some fixes that remove undefined behavior. See commit message for details, and here for more information:

http://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wsequence_002dpoint-309
