### PR TITLE
Fixups for GCC's unused variable warning.

### DIFF
--- a/shared/DSPFilters/source/Documentation.cpp
+++ b/shared/DSPFilters/source/Documentation.cpp
@@ -425,6 +425,12 @@ void UsageExamples ()
 
     // calculate response at frequency 440 Hz
     Dsp::complex_t response = f.response (440./44100);
+
+    std::ostringstream os;
+
+    os << "response = " << response << "\n";
+
+    std::cout << os.str();
   }
 
   // Extract coefficients from a Cascade

--- a/shared/DSPFilters/source/PoleFilter.cpp
+++ b/shared/DSPFilters/source/PoleFilter.cpp
@@ -181,7 +181,6 @@ BandPassTransform::BandPassTransform (double fc,
     //
 #ifndef NDEBUG
     ComplexPair p2 = transform (pair.poles.second);
-    ComplexPair z2 = transform (pair.zeros.second);
     assert (p2.first == std::conj (p1.first));
     assert (p2.second == std::conj (p1.second));
 #endif


### PR DESCRIPTION
This patch keeps DSPFilters from triggering GCC's `-Wunused-but-set-variable` warning.

Merging both this and pull request 10 (https://github.com/vinniefalco/DSPFilters/pull/10) allows DSPFilters to build without triggering any of the GCC warnings enabled by `-Wall`:

```
$ CXXFLAGS='-Wall' ./waf
```

This allows users to build with `-Wall -Werror` ("all" warnings enabled, treat warnings as errors), which is common enough practice to be worth supporting.
