### PR TITLE
RootFinder.h: added omitted header

### DIFF
--- a/shared/DSPFilters/include/DspFilters/RootFinder.h
+++ b/shared/DSPFilters/include/DspFilters/RootFinder.h
@@ -38,6 +38,7 @@ THE SOFTWARE.
 
 #include "DspFilters/Common.h"
 #include "DspFilters/Types.h"
+#include <algorithm>
 
 namespace Dsp {
 


### PR DESCRIPTION
Added <algorithm> header to prevent VC2015 build error (It contains std::min() and std::max()).