### PR TITLE
Linux build

### DIFF
--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.0)
+
+project (DSPFilters_Solution)
+
+set (CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_BUILD_TYPE Release)
+
+if((${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC))
+  set(MYFLAGS "/O2 /WX- /MT")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MYFLAGS}")
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${MYFLAGS}")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${MYFLAGS}")
+  set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} ${MYFLAGS}")
+  include(CheckSymbolExists)
+  check_symbol_exists(snprintf "stdio.h" HAVE_SNPRINTF)
+  if(NOT HAVE_SNPRINTF)
+  add_definitions(-Dsnprintf=_snprintf)
+  endif()
+endif()
+
+add_subdirectory(DSPFilters)
+#add_subdirectory(JuceAmalgam)
+#add_subdirectory(DSPFiltersDemo)

--- a/shared/DSPFilters/CMakeLists.txt
+++ b/shared/DSPFilters/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.0)
+
+project (DSPFilters CXX)
+
+aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/source SOURCE_LIB)
+
+add_library(${PROJECT_NAME} STATIC ${SOURCE_LIB})
+
+target_include_directories(${PROJECT_NAME} 
+PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
+


### PR DESCRIPTION
This library can be easily built on Linux platform. But I do not see any makefiles ..
With my changes will be possible to create the project files for all platforms (including Visual Studio, of course), by just typing:
```
cd DSPFilters/shared
mkdir build
cd build
cmake ..
```
Then, you can just type "make", if you on Linux. In Windows, you can open the generated project file.

Thats all.
